### PR TITLE
fix(dispatch): GraphQL replaceActorsForAssignable replaces REST agent_assignment

### DIFF
--- a/.github/workflows/orchestrator-redesign-prompt.xml
+++ b/.github/workflows/orchestrator-redesign-prompt.xml
@@ -304,6 +304,68 @@ material — read them when useful, but you are not obligated to follow them.
     handles everything Copilot is suited for.
   </copilot-dispatches>
 
+  <copilot-dispatch-method>
+    HOW to actually trigger a Copilot dispatch. Authorization is settled
+    in <code>COPILOT-DISPATCHES</code> above; this section is the
+    mechanism.
+
+    Use <code>tools/dispatch-task</code>:
+
+    <pre><![CDATA[
+tools/dispatch-task \
+  --title "[redesign-research] Short title" \
+  --body-file /tmp/dispatch-body.md \
+  --label agent-task \
+  --label research-only \
+  --skip-pipeline-gate
+    ]]></pre>
+
+    The tool creates the issue via REST, then assigns the Copilot agent
+    via the GraphQL <code>replaceActorsForAssignable</code> mutation
+    (REST silently drops bot logins from <code>assignees</code>; GraphQL
+    is the only working path). Copilot connects within ~10–15 seconds
+    of assignment. The dispatch is recorded in <code>docs/state.json</code>
+    with a receipt commit pushed to master.
+
+    <strong>Required:</strong> <code>--skip-pipeline-gate</code> in
+    redesign mode. The gate runs <code>tools/pipeline-check</code> which
+    is not maintained during redesign; without the flag the dispatch
+    will be blocked.
+
+    <strong>Required labels:</strong> <code>agent-task</code> plus exactly
+    one of <code>research-only</code> / <code>feedback-only</code> /
+    <code>implementation</code> (the dispatch type from
+    <code>COPILOT-DISPATCHES</code>).
+
+    For end-of-cycle review dispatches use <code>tools/dispatch-review</code>
+    with the same <code>--skip-pipeline-gate</code> flag — same mechanism,
+    different state-tracking. Redesign mode rarely needs this; it is
+    listed for completeness.
+
+    Verify the dispatch fired by checking issue events for
+    <code>connected</code> from actor <code>Copilot</code>:
+
+    <pre><![CDATA[
+gh api repos/EvaLok/schema-org-json-ld/issues/NNN/events \
+  --jq '.[] | select(.actor.login == "Copilot") | {event, created_at}'
+    ]]></pre>
+
+    If <code>assigned</code> appears but <code>connected</code> does not
+    appear within ~60 seconds, Copilot may be rate-limiting or the bot
+    actor ID may have rotated — see
+    <code>record-dispatch::assign_copilot_agent</code> for the
+    re-discovery query.
+
+    <strong>Forbidden:</strong> raw <code>gh issue create</code> for
+    Copilot dispatches. Without the GraphQL assignment step, Copilot
+    never connects and the issue sits forever (cycles 63–92 demonstrated
+    this — six dispatches stuck for 15+ cycles each). Always go through
+    <code>tools/dispatch-task</code> or
+    <code>tools/dispatch-review</code>.
+
+    See ADR 0016 for the full diagnosis and verification.
+  </copilot-dispatch-method>
+
   <audit-as-peer>
     The audit repo (EvaLok/schema-org-json-ld-audit) runs an independent
     orchestrator that audits this repo. The two repos communicate via

--- a/doc/adr/0016-copilot-dispatch-mechanism-graphql.md
+++ b/doc/adr/0016-copilot-dispatch-mechanism-graphql.md
@@ -1,0 +1,90 @@
+# ADR 0016: Copilot Dispatch Mechanism — GraphQL Replaces REST `agent_assignment`
+
+## Status
+
+Accepted (2026-05-08). Applies to all Copilot dispatches from this repository (production and redesign mode). Implemented in `tools/rust/crates/record-dispatch/src/lib.rs` (new `assign_copilot_agent` helper), `tools/rust/crates/dispatch-task/src/main.rs` (rewrite of issue payload + assignment step + `--skip-pipeline-gate` flag), `tools/rust/crates/dispatch-review/src/main.rs` (parallel rewrite), and `.github/workflows/orchestrator-redesign-prompt.xml` (new `<copilot-dispatch-method>` section). Verified end-to-end via test issues [#2879](https://github.com/EvaLok/schema-org-json-ld/issues/2879) and [#2881](https://github.com/EvaLok/schema-org-json-ld/issues/2881).
+
+## Context
+
+From cycle 16 onwards (2026-04-28+), Copilot dispatches stopped wakening the coding agent. Issues were created with `agent-task` + `research-only` / `feedback-only` labels, but Copilot never connected. As of 2026-05-08 there were six issues stuck waiting:
+
+- [#2833](https://github.com/EvaLok/schema-org-json-ld/issues/2833) oh-my-codex deeper read (29 cycles waiting)
+- [#2842](https://github.com/EvaLok/schema-org-json-ld/issues/2842) PAI deeper read (21 cycles)
+- [#2847](https://github.com/EvaLok/schema-org-json-ld/issues/2847) oh-my-claudecode survey (17 cycles)
+- [#2851](https://github.com/EvaLok/schema-org-json-ld/issues/2851) symphony survey (15 cycles)
+- [#2869](https://github.com/EvaLok/schema-org-json-ld/issues/2869) Phase 2 candidate critique (cycle 93)
+- [#2870](https://github.com/EvaLok/schema-org-json-ld/issues/2870) cycle 91-92 sharpening critique (cycle 93)
+
+The closed-loop cold-reader iteration that ADR 0015 was meant to break depended on the orchestrator successfully dispatching new research. With dispatch silently broken, ADR 0015 could only deliver substantive-focal change in the form of orchestrator-internal work (cross-system synthesis, implications mining, retrospectives). The deeper-read research front never advanced.
+
+Three layers of breakage compound to produce the symptom:
+
+1. **GitHub API** — REST `/issues` POST with `"assignees": ["copilot-swe-agent[bot]"]` no longer reliably triggers Copilot. The REST `/assignees` endpoint rejects bot logins entirely; the legacy `agent_assignment` REST field appears to have stopped having effect. The only verified working path to assign the Copilot coding agent is the GraphQL `replaceActorsForAssignable` mutation.
+
+2. **`tools/dispatch-task` and `tools/dispatch-review` Rust binaries** codified the broken REST template literally. Their unit tests asserted on the broken payload shape (`assignees == ["copilot-swe-agent[bot]"]`, `agent_assignment.target_repo == MAIN_REPO`, etc.), locking the bug in.
+
+3. **Redesign-mode prompt** (`orchestrator-redesign-prompt.xml`, in use since 2026-04-27) had a `<copilot-dispatches>` section authorizing the three dispatch types but no `<dispatch-method>` block specifying how to actually execute one. The orchestrator improvised with raw `gh issue create --label agent-task --assignee EvaLok`, which doesn't even attempt bot assignment. The production prompt did have a `<dispatch-method>` block, but it pointed at the broken layer-2 template.
+
+Verification (2026-05-08):
+
+- Manual GraphQL `replaceActorsForAssignable` mutation against the six stuck issues unblocked them within seconds — Copilot connected ~10s after assignment for each. Within hours, all six produced Copilot working branches.
+- An isolated test workflow ([`.github/workflows/copilot-dispatch-test.yml`](../../.github/workflows/copilot-dispatch-test.yml)) running `claude-code-action@v1` with `ORCHESTRATOR_PAT` driving `gh api graphql` reproduced the same success: test issues #2879 and #2881 both showed `assigned` and `connected` events from Copilot within 10 seconds of mutation. Mechanism works identically from CI as from interactive sessions.
+
+## Decision
+
+Replace the REST-based dispatch mechanism with a two-step flow:
+
+1. Create the issue via REST POST with a minimal payload (title, body, labels). Drop `assignees` and `agent_assignment` fields entirely — they were dead weight at best and active footguns at worst.
+2. After successful creation, call the GraphQL `replaceActorsForAssignable` mutation using the issue's `node_id` (returned by the REST POST response) to assign actor IDs `BOT_kgDOC9w8XQ` (`copilot-swe-agent`) and `U_kgDOALttcg` (`EvaLok`).
+
+**Implementation:**
+
+- `record_dispatch::assign_copilot_agent(issue_node_id)` — shared helper that runs the GraphQL mutation via `gh api graphql`. Constants `COPILOT_AGENT_ACTOR_ID` and `EVALOK_USER_ACTOR_ID` are exposed publicly with re-discovery queries documented in their doc comments.
+- `dispatch-task` and `dispatch-review` rewritten: `IssuePayload`/`ReviewIssuePayload` reduced to `{ title, body, labels }`; `CreatedIssue` extended with `node_id`; both crates call `assign_copilot_agent` after `create_issue` succeeds. Failures in the assignment step log a warning but do not roll back the dispatch — the issue exists, and assignment can be retried manually.
+- New `--skip-pipeline-gate` flag on both crates. The pipeline-check gate (`dispatch-task`) and C5.5 review-dispatch gate (`dispatch-review`) are not maintained in redesign mode; the flag bypasses them with an explicit log line. The gates remain enforced by default for production-mode use.
+- Redesign prompt updated with a new `<copilot-dispatch-method>` section under `<copilot-dispatches>` instructing the orchestrator to use `tools/dispatch-task --skip-pipeline-gate`. Raw `gh issue create` for Copilot dispatches is explicitly forbidden.
+
+**Scope:** All Copilot dispatches from this repository, production and redesign modes. The production prompt's `<dispatch-method>` block still references the old broken REST template; that is out of scope for this ADR (production mode is dormant during redesign), but should be updated when redesign mode ends.
+
+## Consequences
+
+### Positive
+
+- Copilot dispatches actually wake Copilot. Six stuck dispatches unblocked (#2833, #2842, #2847, #2851, #2869, #2870); all produced working branches within hours.
+- The polarity directive from ADR 0015 (research expansion as default substantive focal) becomes operationally effective. Cycle-63+ deeper-read dispatches that were blocked at the dispatch layer can now actually run.
+- The dispatch tool surface (`tools/dispatch-task`, `tools/dispatch-review`) is restored as the canonical path. Future orchestrator changes that touch dispatching benefit from the centralized state-recording, receipt-commit, and (when the gates are enforced) pipeline integration.
+- Bot/user actor IDs are documented as constants with re-discovery queries — when GitHub rotates or the IDs change, the failure mode is a clear error from the GraphQL mutation, and the recovery path is the documented query.
+
+### Negative
+
+- The actor IDs are hardcoded. If GitHub rotates bot IDs without notice, dispatches will silently fail until the IDs are re-discovered and updated. Mitigation: the `assign_copilot_agent` failure path explicitly references the re-discovery query and ADR 0016, and the integration test workflow can be re-run on demand to detect breakage.
+- The pipeline gate is now bypassable with an explicit flag. Future production-mode use must be careful not to leave `--skip-pipeline-gate` enabled by default. Mitigation: the flag prints a warning to stderr each time it is used, and the redesign-mode prompt is the only place it is currently invoked.
+- `assign_copilot_agent` failures are logged but do not roll back the dispatch. A failure produces an issue without Copilot assigned, requiring manual intervention. Acceptable trade: silent rollback would mean a dispatch the orchestrator believes failed but the issue actually exists, which is worse.
+- `agent_assignment.model` was the previous knob for selecting `gpt-5.4` vs `gpt-5.5` per dispatch. With the field removed, Copilot uses the user/org default model. If per-dispatch model selection becomes important, it will need a separate mechanism (likely a follow-on GraphQL mutation or Copilot configuration API).
+
+### Trade-offs
+
+- Hardcoded actor IDs vs runtime discovery: chose hardcoded for simplicity and to avoid an extra round-trip per dispatch. Discovery query is documented for the rotation case.
+- Two REST + GraphQL calls vs single combined mechanism: GraphQL doesn't allow mixing a query and a mutation in one operation, and the REST POST response already includes `node_id`, so two calls is the minimum. Acceptable.
+- Adding `--skip-pipeline-gate` vs auto-detecting redesign mode: chose explicit flag. Auto-detection couples dispatch mechanics to mode-state coupling, and gives no audit trail when the gate is bypassed. Explicit flag with stderr log is auditable.
+
+## Alternatives Considered
+
+**B — Inline GraphQL mutation in the redesign prompt only (Shape A from initial diagnosis).** Rejected: leaves `tools/dispatch-task` and `tools/dispatch-review` broken as latent debt for production-mode return. Two paths for the same operation invites drift. The deeper fix is roughly the same effort once test fixture updates are factored in.
+
+**C — Update REST `/assignees` POST endpoint with bot login.** Rejected: GitHub's REST endpoint silently drops bot logins. Verified by inspecting the working pre-bug issue (#2762) — both `Copilot` and `EvaLok` appear in the assignees array, which would only be possible via a GraphQL path or an internal-only REST extension that has since been removed.
+
+**D — Discover actor IDs at runtime via `suggestedActors` query on every dispatch.** Rejected: adds latency and an extra failure surface to every dispatch for a problem (ID rotation) that has not been observed. Hardcoded constants with documented re-discovery is a better trade.
+
+**E — Restore the `agent_assignment` REST field via undocumented API.** Rejected: even when the field was effective, it was a non-standard REST extension and offered no transparency on what it did. GraphQL `replaceActorsForAssignable` is documented, stable, and the same mechanism the GitHub UI uses internally for assignment changes.
+
+## Cross-references
+
+- ADR 0015 — Cycle Composition Polarity for Redesign Mode. ADR 0015's effectiveness was gated on dispatches actually firing; this ADR removes that gate.
+- Issue [#2829](https://github.com/EvaLok/schema-org-json-ld/issues/2829) — input-from-eva directive announcing the polarity inversion (cycle 62).
+- PR [#2830](https://github.com/EvaLok/schema-org-json-ld/pull/2830) — polarity directive merge (commit `fcbb9023`).
+- Test issues [#2879](https://github.com/EvaLok/schema-org-json-ld/issues/2879) and [#2881](https://github.com/EvaLok/schema-org-json-ld/issues/2881) — end-to-end CI verification of the GraphQL mechanism.
+- Stuck dispatches: [#2833](https://github.com/EvaLok/schema-org-json-ld/issues/2833), [#2842](https://github.com/EvaLok/schema-org-json-ld/issues/2842), [#2847](https://github.com/EvaLok/schema-org-json-ld/issues/2847), [#2851](https://github.com/EvaLok/schema-org-json-ld/issues/2851), [#2869](https://github.com/EvaLok/schema-org-json-ld/issues/2869), [#2870](https://github.com/EvaLok/schema-org-json-ld/issues/2870) — all unblocked manually via GraphQL mutation, then producing Copilot branches.
+- Working pre-bug reference: PR [#2763](https://github.com/EvaLok/schema-org-json-ld/pull/2763) (cycle 15 AutoGen research, authored by `app/copilot-swe-agent`) — last successful Copilot dispatch before the regression.
+- Production prompt: `.github/workflows/orchestrator-prompt.xml` SECTION 6 `<coding-agent>` — contains the broken REST template (lines 408-428); out of scope for this ADR but should be updated when redesign mode ends.
+- Test workflow: `.github/workflows/copilot-dispatch-test.yml` and `.github/workflows/copilot-dispatch-test-prompt.md` — preserved as a smoke test for future auth/scope or actor-ID changes.

--- a/tools/rust/crates/dispatch-review/src/main.rs
+++ b/tools/rust/crates/dispatch-review/src/main.rs
@@ -1,8 +1,9 @@
 use clap::Parser;
 use record_dispatch::{
-    apply_dispatch_patch, build_dispatch_patch, dispatch_commit_message, enforce_pipeline_gate,
-    restore_sealed_last_cycle, should_sync_last_cycle_summary, snapshot_sealed_last_cycle,
-    sync_last_cycle_summary_after_dispatch, update_review_dispatch_tracking, ProcessRunner,
+    apply_dispatch_patch, assign_copilot_agent, build_dispatch_patch, dispatch_commit_message,
+    enforce_pipeline_gate, restore_sealed_last_cycle, should_sync_last_cycle_summary,
+    snapshot_sealed_last_cycle, sync_last_cycle_summary_after_dispatch,
+    update_review_dispatch_tracking, ProcessRunner,
 };
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -15,7 +16,6 @@ use std::path::{Path, PathBuf};
 use std::process::{Command, Output, Stdio};
 
 const MAIN_REPO: &str = "EvaLok/schema-org-json-ld";
-const BASE_BRANCH: &str = "master";
 
 #[derive(Parser, Debug)]
 #[command(name = "dispatch-review")]
@@ -43,14 +43,11 @@ struct Cli {
     /// Record an already-created review issue number without calling gh api (testing/recovery)
     #[arg(long)]
     record_only: Option<u64>,
-}
 
-#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
-struct AgentAssignment {
-    target_repo: String,
-    base_branch: String,
-    model: String,
-    custom_instructions: String,
+    /// Skip the C5.5 review-dispatch gate (use in redesign mode where the
+    /// C5.5 gate is not maintained).
+    #[arg(long)]
+    skip_pipeline_gate: bool,
 }
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
@@ -58,14 +55,13 @@ struct ReviewIssuePayload {
     title: String,
     body: String,
     labels: Vec<String>,
-    assignees: Vec<String>,
-    agent_assignment: AgentAssignment,
 }
 
 #[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
 struct CreatedIssue {
     number: u64,
     html_url: String,
+    node_id: String,
 }
 
 fn main() {
@@ -80,7 +76,7 @@ fn run(cli: Cli) -> Result<(), String> {
     let current_cycle = resolve_cycle(cli.cycle, &cli.repo_root)?;
     let body = read_body_file(&cli.body_file)?;
     let model = state_schema::default_agent_model(&cli.repo_root)?;
-    let payload = build_issue_payload(current_cycle, &body, &model);
+    let payload = build_issue_payload(current_cycle, &body);
 
     if cli.dry_run {
         println!(
@@ -95,9 +91,21 @@ fn run(cli: Cli) -> Result<(), String> {
         CreatedIssue {
             number: issue_number,
             html_url: format!("https://github.com/{MAIN_REPO}/issues/{issue_number}"),
+            node_id: String::new(),
         }
     } else {
-        create_issue(&payload)?
+        let issue = create_issue(&payload)?;
+        // Assign Copilot via GraphQL (REST drops bot logins). Failures here
+        // do NOT roll back the dispatch — the issue exists and assignment
+        // can be retried manually. See ADR 0016.
+        if let Err(error) = assign_copilot_agent(&issue.node_id) {
+            eprintln!(
+                "warning: created review issue #{} but failed to assign Copilot agent: {}. \
+                 Re-run the GraphQL replaceActorsForAssignable mutation manually.",
+                issue.number, error
+            );
+        }
+        issue
     };
     let state_result = record_created_issue(
         &cli.repo_root,
@@ -105,6 +113,7 @@ fn run(cli: Cli) -> Result<(), String> {
         created_issue.number,
         &payload.title,
         &model,
+        cli.skip_pipeline_gate,
     );
     if let Err(error) = state_result {
         return Err(format!(
@@ -120,18 +129,11 @@ fn run(cli: Cli) -> Result<(), String> {
     Ok(())
 }
 
-fn build_issue_payload(cycle: u64, body: &str, model: &str) -> ReviewIssuePayload {
+fn build_issue_payload(cycle: u64, body: &str) -> ReviewIssuePayload {
     ReviewIssuePayload {
         title: format!("[Cycle Review] Cycle {} end-of-cycle review", cycle),
         body: body.to_string(),
         labels: vec!["agent-task".to_string(), "cycle-review".to_string()],
-        assignees: vec!["copilot-swe-agent[bot]".to_string()],
-        agent_assignment: AgentAssignment {
-            target_repo: MAIN_REPO.to_string(),
-            base_branch: BASE_BRANCH.to_string(),
-            model: model.to_string(),
-            custom_instructions: String::new(),
-        },
     }
 }
 
@@ -184,10 +186,15 @@ fn record_created_issue(
     issue: u64,
     title: &str,
     model: &str,
+    skip_pipeline_gate: bool,
 ) -> Result<(), String> {
-    // Enforce pipeline gate (logs warning for review dispatches, blocks for others)
-    if let Err(error) = enforce_pipeline_gate(repo_root, true, &ProcessRunner) {
-        return Err(format!("pipeline gate check failed: {:?}", error));
+    if skip_pipeline_gate {
+        eprintln!("--skip-pipeline-gate: bypassing C5.5 review-dispatch gate (redesign mode)");
+    } else {
+        // Enforce pipeline gate (logs warning for review dispatches, blocks for others)
+        if let Err(error) = enforce_pipeline_gate(repo_root, true, &ProcessRunner) {
+            return Err(format!("pipeline gate check failed: {:?}", error));
+        }
     }
 
     let mut state = read_state_value(repo_root)?;
@@ -323,26 +330,30 @@ mod tests {
         assert!(help.contains("--repo-root"));
         assert!(help.contains("--dry-run"));
         assert!(help.contains("--record-only"));
+        assert!(help.contains("--skip-pipeline-gate"));
     }
 
     #[test]
-    fn build_issue_payload_includes_labels_assignee_and_agent_assignment() {
-        let payload = build_issue_payload(200, "Review body", "gpt-5.4");
+    fn build_issue_payload_omits_legacy_fields_for_graphql_assignment() {
+        let payload = build_issue_payload(200, "Review body");
 
         assert_eq!(
             payload.title,
             "[Cycle Review] Cycle 200 end-of-cycle review"
         );
         assert_eq!(payload.labels, vec!["agent-task", "cycle-review"]);
-        assert_eq!(payload.assignees, vec!["copilot-swe-agent[bot]"]);
-        assert_eq!(
-            payload.agent_assignment,
-            AgentAssignment {
-                target_repo: MAIN_REPO.to_string(),
-                base_branch: BASE_BRANCH.to_string(),
-                model: "gpt-5.4".to_string(),
-                custom_instructions: String::new(),
-            }
+        // Bot assignee and agent_assignment are intentionally absent —
+        // REST silently drops bot logins from `assignees`, and the legacy
+        // `agent_assignment` REST field is no longer functional. Copilot
+        // is assigned via GraphQL after issue creation. See ADR 0016.
+        let serialized = serde_json::to_value(&payload).expect("serialize");
+        assert!(
+            serialized.get("assignees").is_none(),
+            "assignees field must not appear in REST POST payload: {serialized}"
+        );
+        assert!(
+            serialized.get("agent_assignment").is_none(),
+            "agent_assignment field must not appear in REST POST payload: {serialized}"
         );
     }
 
@@ -395,6 +406,7 @@ mod tests {
             2521,
             "[Cycle Review] Cycle 495 end-of-cycle review",
             "gpt-5.4",
+            true,
         )
         .expect("record should succeed");
 

--- a/tools/rust/crates/dispatch-task/src/main.rs
+++ b/tools/rust/crates/dispatch-task/src/main.rs
@@ -1,6 +1,6 @@
 use clap::{ArgAction, Parser};
 use record_dispatch::{
-    apply_dispatch_patch, build_dispatch_patch, concurrency_warning_message,
+    apply_dispatch_patch, assign_copilot_agent, build_dispatch_patch, concurrency_warning_message,
     dispatch_commit_message, enforce_pipeline_gate, push_to_origin_master, resolve_model,
     should_sync_last_cycle_summary, sync_last_cycle_summary_after_dispatch, CommandRunner,
     PipelineGateError, ProcessRunner,
@@ -17,7 +17,6 @@ use std::path::{Path, PathBuf};
 use std::process::{Command, Output, Stdio};
 
 const MAIN_REPO: &str = "EvaLok/schema-org-json-ld";
-const BASE_BRANCH: &str = "master";
 
 #[derive(Parser, Debug)]
 #[command(name = "dispatch-task")]
@@ -30,7 +29,7 @@ struct Cli {
     #[arg(long)]
     body_file: PathBuf,
 
-    /// Model for agent_assignment
+    /// Coding-agent model identifier recorded in docs/state.json
     #[arg(long)]
     model: Option<String>,
 
@@ -49,6 +48,11 @@ struct Cli {
     /// Print what would be created without actually dispatching
     #[arg(long)]
     dry_run: bool,
+
+    /// Skip the pipeline-check gate (use in redesign mode where the
+    /// production pipeline is not actively maintained).
+    #[arg(long)]
+    skip_pipeline_gate: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -87,26 +91,17 @@ impl AddressedFinding {
 }
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
-struct AgentAssignment {
-    target_repo: String,
-    base_branch: String,
-    model: String,
-    custom_instructions: String,
-}
-
-#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 struct IssuePayload {
     title: String,
     body: String,
     labels: Vec<String>,
-    assignees: Vec<String>,
-    agent_assignment: AgentAssignment,
 }
 
 #[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
 struct CreatedIssue {
     number: u64,
     html_url: String,
+    node_id: String,
 }
 
 /// Trait that abstracts the GitHub API call for testability.
@@ -179,7 +174,7 @@ fn run_with_runners(
 ) -> Result<(), String> {
     let body = read_body_file(&cli.body_file, cli.dry_run)?;
     let model = resolve_model(cli.model.as_deref(), &cli.repo_root)?;
-    let payload = build_issue_payload(&cli.title, &body, &cli.labels, &model);
+    let payload = build_issue_payload(&cli.title, &body, &cli.labels);
 
     if cli.dry_run {
         println!(
@@ -191,26 +186,41 @@ fn run_with_runners(
         return Ok(());
     }
 
-    // Validate pipeline gate before creating the issue.
-    let pipeline_warning = match enforce_pipeline_gate(&cli.repo_root, false, pipeline_runner) {
-        Ok(warning) => warning,
-        Err(PipelineGateError::ReviewDispatchBlocked(message)) => {
-            return Err(message);
+    if cli.skip_pipeline_gate {
+        warn("--skip-pipeline-gate: bypassing pipeline-check (redesign mode)");
+    } else {
+        let pipeline_warning = match enforce_pipeline_gate(&cli.repo_root, false, pipeline_runner) {
+            Ok(warning) => warning,
+            Err(PipelineGateError::ReviewDispatchBlocked(message)) => {
+                return Err(message);
+            }
+            Err(PipelineGateError::ExecutionFailed(detail)) => {
+                eprintln!("pipeline-check execution error: {detail}");
+                return Err(record_dispatch::PIPELINE_GATE_FAILURE_MESSAGE.to_string());
+            }
+            Err(PipelineGateError::Failed) => {
+                return Err(record_dispatch::PIPELINE_GATE_FAILURE_MESSAGE.to_string());
+            }
+        };
+        if let Some(warning) = pipeline_warning {
+            warn(warning);
         }
-        Err(PipelineGateError::ExecutionFailed(detail)) => {
-            eprintln!("pipeline-check execution error: {detail}");
-            return Err(record_dispatch::PIPELINE_GATE_FAILURE_MESSAGE.to_string());
-        }
-        Err(PipelineGateError::Failed) => {
-            return Err(record_dispatch::PIPELINE_GATE_FAILURE_MESSAGE.to_string());
-        }
-    };
-    if let Some(warning) = pipeline_warning {
-        warn(warning);
     }
 
     // Create the GitHub issue first; only modify state on success.
     let created_issue = api_runner.create_issue(&payload)?;
+
+    // Assign the Copilot coding agent via GraphQL. Failures here do NOT
+    // roll back the dispatch — the issue exists and assignment can be
+    // retried manually. Log a warning and continue to state recording.
+    if let Err(error) = assign_copilot_agent(&created_issue.node_id) {
+        warn(&format!(
+            "warning: created issue #{} but failed to assign Copilot agent: {}. \
+             Re-run the GraphQL replaceActorsForAssignable mutation manually \
+             (see record-dispatch::assign_copilot_agent and ADR 0016).",
+            created_issue.number, error
+        ));
+    }
 
     // Record the dispatch in state.json.
     match record_dispatch_state(
@@ -380,18 +390,11 @@ fn reconcile_review_history_dispatches(
     Ok(())
 }
 
-fn build_issue_payload(title: &str, body: &str, labels: &[String], model: &str) -> IssuePayload {
+fn build_issue_payload(title: &str, body: &str, labels: &[String]) -> IssuePayload {
     IssuePayload {
         title: title.to_string(),
         body: body.to_string(),
         labels: labels.to_vec(),
-        assignees: vec!["copilot-swe-agent[bot]".to_string()],
-        agent_assignment: AgentAssignment {
-            target_repo: MAIN_REPO.to_string(),
-            base_branch: BASE_BRANCH.to_string(),
-            model: model.to_string(),
-            custom_instructions: String::new(),
-        },
     }
 }
 
@@ -564,17 +567,25 @@ mod tests {
             "Fix the thing",
             "Body text here",
             &["agent-task".to_string()],
-            "gpt-5.4",
         );
 
         assert_eq!(payload.title, "Fix the thing");
         assert_eq!(payload.body, "Body text here");
         assert_eq!(payload.labels, vec!["agent-task"]);
-        assert_eq!(payload.assignees, vec!["copilot-swe-agent[bot]"]);
-        assert_eq!(payload.agent_assignment.target_repo, MAIN_REPO);
-        assert_eq!(payload.agent_assignment.base_branch, BASE_BRANCH);
-        assert_eq!(payload.agent_assignment.model, "gpt-5.4");
-        assert_eq!(payload.agent_assignment.custom_instructions, "");
+        // Bot assignee and agent_assignment intentionally excluded from the
+        // REST payload — REST silently drops bot logins from `assignees`,
+        // and the legacy `agent_assignment` field is no longer functional.
+        // Copilot is assigned via GraphQL after issue creation.
+        // See ADR 0016.
+        let serialized = serde_json::to_value(&payload).expect("serialize");
+        assert!(
+            serialized.get("assignees").is_none(),
+            "assignees field must not appear in REST POST payload: {serialized}"
+        );
+        assert!(
+            serialized.get("agent_assignment").is_none(),
+            "agent_assignment field must not appear in REST POST payload: {serialized}"
+        );
     }
 
     #[test]
@@ -632,6 +643,7 @@ mod tests {
                 addresses_finding: Vec::new(),
                 repo_root: repo.path().to_path_buf(),
                 dry_run: true,
+                skip_pipeline_gate: false,
             },
             &pipeline_runner,
             &api_runner,
@@ -671,6 +683,7 @@ mod tests {
                 addresses_finding: Vec::new(),
                 repo_root: repo.path().to_path_buf(),
                 dry_run: true,
+                skip_pipeline_gate: false,
             },
             &pipeline_runner,
             &api_runner,
@@ -692,6 +705,7 @@ mod tests {
         assert!(help.contains("--addresses-finding"));
         assert!(help.contains("--repo-root"));
         assert!(help.contains("--dry-run"));
+        assert!(help.contains("--skip-pipeline-gate"));
     }
 
     #[test]

--- a/tools/rust/crates/dispatch-task/tests/dispatch_task_does_not_mutate_previous_worklog.rs
+++ b/tools/rust/crates/dispatch-task/tests/dispatch_task_does_not_mutate_previous_worklog.rs
@@ -185,7 +185,7 @@ impl TempFixture {
         fs::write(&self.body_file, "dispatch body\n").expect("body file should be written");
         fs::write(
             self.bin_root.join("gh"),
-            "#!/usr/bin/env bash\nset -euo pipefail\ncat >/dev/null\nprintf '%s\\n' '{\"number\":602,\"html_url\":\"https://github.com/EvaLok/schema-org-json-ld/issues/602\"}'\n",
+            "#!/usr/bin/env bash\nset -euo pipefail\ncat >/dev/null\nprintf '%s\\n' '{\"number\":602,\"html_url\":\"https://github.com/EvaLok/schema-org-json-ld/issues/602\",\"node_id\":\"I_kwDOTEST00000000\"}'\n",
         )
         .expect("fake gh should be written");
         make_executable(&self.bin_root.join("gh"));

--- a/tools/rust/crates/record-dispatch/src/lib.rs
+++ b/tools/rust/crates/record-dispatch/src/lib.rs
@@ -6,6 +6,17 @@ pub const PIPELINE_GATE_FAILURE_MESSAGE: &str =
     "Cannot dispatch: pipeline-check failed. Fix failures before dispatching.";
 pub const REVIEW_DISPATCH_WARNING: &str =
     "Pipeline gate bypassed for review dispatch (--review-dispatch)";
+
+/// GraphQL actor ID for the GitHub Copilot coding agent
+/// (`copilot-swe-agent`). Stable for `EvaLok/schema-org-json-ld`.
+/// Re-discover via:
+/// `gh api graphql -f query='query { repository(owner: "EvaLok", name: "schema-org-json-ld")
+///   { suggestedActors(capabilities: [CAN_BE_ASSIGNED], first: 10)
+///     { nodes { login __typename ... on Bot { id } ... on User { id } } } } }'`
+pub const COPILOT_AGENT_ACTOR_ID: &str = "BOT_kgDOC9w8XQ";
+
+/// GraphQL actor ID for the EvaLok user. Same re-discovery query as above.
+pub const EVALOK_USER_ACTOR_ID: &str = "U_kgDOALttcg";
 const PIPELINE_CHECK_ARGS: [&str; 9] = [
     "tools/pipeline-check",
     "--exclude-step",
@@ -596,6 +607,49 @@ pub fn push_to_origin_master(repo_root: &Path) -> Result<(), String> {
     if !output.status.success() {
         return Err(command_failure_message("git push origin master", &output));
     }
+    Ok(())
+}
+
+/// Assign the GitHub Copilot coding agent (and EvaLok) to an issue via the
+/// GraphQL `replaceActorsForAssignable` mutation. This is the only path that
+/// successfully wakes Copilot for a dispatched issue — REST `assignees`
+/// silently drops bot logins, and the legacy `agent_assignment` REST field is
+/// no longer functional. See ADR 0016.
+///
+/// Takes the issue's GraphQL node ID (returned by REST `gh api .../issues`
+/// POST as `node_id`, or queryable via GraphQL `repository.issue(number).id`).
+/// Returns `Ok(())` on success; on error returns the underlying gh failure
+/// message verbatim — caller decides whether to fail the dispatch or
+/// continue (the issue was already created).
+pub fn assign_copilot_agent(issue_node_id: &str) -> Result<(), String> {
+    let query = format!(
+        "mutation($id: ID!) {{ \
+           replaceActorsForAssignable(input: {{ \
+             assignableId: $id, \
+             actorIds: [\"{COPILOT_AGENT_ACTOR_ID}\", \"{EVALOK_USER_ACTOR_ID}\"] \
+           }}) {{ \
+             assignable {{ ... on Issue {{ number assignees(first: 5) {{ nodes {{ login }} }} }} }} \
+           }} \
+         }}"
+    );
+
+    let output = Command::new("gh")
+        .arg("api")
+        .arg("graphql")
+        .arg("-f")
+        .arg(format!("query={query}"))
+        .arg("-F")
+        .arg(format!("id={issue_node_id}"))
+        .output()
+        .map_err(|error| format!("failed to execute gh api graphql: {error}"))?;
+
+    if !output.status.success() {
+        return Err(command_failure_message(
+            "gh api graphql replaceActorsForAssignable",
+            &output,
+        ));
+    }
+
     Ok(())
 }
 


### PR DESCRIPTION
## Summary

- Replace REST `agent_assignment` + `assignees: ["copilot-swe-agent[bot]"]` with REST POST + GraphQL `replaceActorsForAssignable` mutation (the only path that wakes Copilot today).
- New shared helper `record_dispatch::assign_copilot_agent` used by both `dispatch-task` and `dispatch-review`.
- `--skip-pipeline-gate` flag on both crates for redesign mode.
- New `<copilot-dispatch-method>` section in the redesign prompt.
- ADR 0016 documents the diagnosis, decision, alternatives.

## Why

See ADR 0016 and #2883 (directive). The orchestrator stopped wakening Copilot from cycle 16+ — six dispatches sat stuck for 15-29 cycles each. Diagnosis: REST silently drops bot logins from `assignees`, and the legacy `agent_assignment` field is no longer functional. Verified mechanism end-to-end from CI before locking it in (test issues #2879/#2881).

## Changes

- `tools/rust/crates/record-dispatch/src/lib.rs` — new `assign_copilot_agent(issue_node_id)` helper, public actor-ID constants with re-discovery queries documented.
- `tools/rust/crates/dispatch-task/src/main.rs` — `IssuePayload` reduced to `{title, body, labels}`; `CreatedIssue` extended with `node_id`; calls `assign_copilot_agent` after `create_issue`; new `--skip-pipeline-gate` flag; tests updated.
- `tools/rust/crates/dispatch-review/src/main.rs` — same pattern.
- `tools/rust/crates/dispatch-task/tests/dispatch_task_does_not_mutate_previous_worklog.rs` — fake gh response now includes `node_id`.
- `.github/workflows/orchestrator-redesign-prompt.xml` — new `<copilot-dispatch-method>` section under `<copilot-dispatches>` instructing orchestrator to use `tools/dispatch-task --skip-pipeline-gate`; forbids raw `gh issue create` for Copilot dispatches.
- `doc/adr/0016-copilot-dispatch-mechanism-graphql.md` — new ADR.

## Test plan

- [x] `cargo build --release` workspace-wide — clean
- [x] `cargo test --release -p dispatch-task -p dispatch-review -p record-dispatch` — all pass
- [x] End-to-end CI verification: test workflow run produced issues #2879/#2881, both showed `assigned` + `connected` events from Copilot within 10s of mutation
- [x] Real-world verification: six previously-stuck research/feedback dispatches (#2833, #2842, #2847, #2851, #2869, #2870) all produced Copilot working branches after manual GraphQL mutation

Closes #2883.
